### PR TITLE
added Koofr to webdav sync options

### DIFF
--- a/readme/apps/sync/webdav.md
+++ b/readme/apps/sync/webdav.md
@@ -9,6 +9,7 @@ WebDAV-compatible services that are known to work with Joplin:
 - [Fastmail](https://www.fastmail.com/)
 - [HiDrive](https://www.strato.fr/stockage-en-ligne/) from Strato. [Setup help](https://github.com/laurent22/joplin/issues/309)
 - [InfiniCLOUD](https://infini-cloud.net/)
+- [Koofr](https://koofr.eu)
 - [Nginx WebDAV Module](https://nginx.org/en/docs/http/ngx_http_dav_module.html)
 - [Nextcloud](https://nextcloud.com/)
 - [OwnCloud](https://owncloud.org/)


### PR DESCRIPTION
Added [Koofr.eu](https://koofr.eu) to WebDAV sync options, checked that it works:

To set it up, choose:

- WebDAV URL: `https://app.koofr.net/dav/Koofr/Joplin` (if `Joplin` is not added, it will write to the root directory of Koofr storage)
- WebDAV username: email you've registered with in Koofr
- WebDAV password: app password created in Preferences > Password in Koofr 

<img width="587" alt="Screenshot 2025-06-27 at 20 07 45" src="https://github.com/user-attachments/assets/f89aea8b-1776-4ae6-b770-3eedce6687d9" />
